### PR TITLE
Support pre-commit framework

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,4 @@
+- id: secret-shield
+  name: Mapbox Secret Shield
+  entry: secret-shield
+  language: node

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,4 @@
 - id: secret-shield
   name: Mapbox Secret Shield
-  entry: secret-shield
+  entry: 'secret-shield --files'
   language: node
-  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,3 +2,4 @@
   name: Mapbox Secret Shield
   entry: secret-shield
   language: node
+  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,5 @@
 - id: secret-shield
   name: Mapbox Secret Shield
-  entry: 'secret-shield --files'
+  entry: 'secret-shield --pre-commit'
   language: node
+  pass_filenames: false


### PR DESCRIPTION
This PR adds support to run secret-shield as a [pre-commit hook](https://pre-commit.com/#new-hooks) by creating a `.pre-commit-hooks.yaml` file. We use `pre-commit` in a few projects at mapbox, and it would be nice to have this support.

cc/ @mapbox/security-and-compliance 