### PR TITLE
Update references from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# secret-shield [![Build Status](https://travis-ci.com/mapbox/secret-shield.svg?token=xWoUHsqdcvsQdxzwqjXH&branch=master)](https://travis-ci.com/mapbox/secret-shield)
+# secret-shield [![Build Status](https://travis-ci.com/mapbox/secret-shield.svg?token=xWoUHsqdcvsQdxzwqjXH&branch=main)](https://travis-ci.com/mapbox/secret-shield)
 
 <!-- MarkdownTOC -->
 
@@ -30,7 +30,7 @@
 
 Some repositories [require secret-shield](./docs/enabledBadge.md) to commit to them. If you don't have secret-shield you'll be blocked from committing to those repos
 
-If secret-shield is installed on your machine, [read this](https://github.com/mapbox/secret-shield/blob/master/docs/commonIssues.md) for common issues with secret-shield and how to fix them.
+If secret-shield is installed on your machine, [read this](https://github.com/mapbox/secret-shield/blob/main/docs/commonIssues.md) for common issues with secret-shield and how to fix them.
 
 <a id="about-secret-shield"></a>
 ## About secret-shield
@@ -49,7 +49,7 @@ If secret-shield is installed on your machine, [read this](https://github.com/ma
 <a id="requirements"></a>
 ## Requirements
 
-`secret-shield` is a Node project [tested with Node 10 & 12](https://github.com/mapbox/secret-shield/blob/master/.travis.yml)
+`secret-shield` is a Node project [tested with Node 10 & 12](https://github.com/mapbox/secret-shield/blob/main/.travis.yml)
 
 `secret-shield` requires `npm >= 6` to install globally. Previous versions of npm will not correcly install the required dependencies.
 
@@ -138,7 +138,7 @@ Security researchers can use secret-shield to find and report leaked secrets to 
 
 By default, secret-shield performs a minimal search: AWS client IDs, Mapbox secure keys, Slack tokens, and GitHub tokens.
 
-If you [perform more advanced searches](https://github.com/mapbox/secret-shield/blob/master/docs/ruleManipulation.md#alternate-ruleset), secret-shield can look for more things, such as AWS secret IDs, “don’t commit” messages, and high-entropy strings.
+If you [perform more advanced searches](https://github.com/mapbox/secret-shield/blob/main/docs/ruleManipulation.md#alternate-ruleset), secret-shield can look for more things, such as AWS secret IDs, “don’t commit” messages, and high-entropy strings.
 
 <a id="it-says-it-found-a-secret-but-it%E2%80%99s-not-what-do-i-do"></a>
 ## It says it found a secret but it’s not, what do I do?
@@ -162,7 +162,7 @@ Secret-shield uses pre-commit hooks; some clients support them, others just forc
 <a id="i-already-have-pre-commit-hooks-for-something-else-will-secret-shield-work-with-them"></a>
 ## I already have pre-commit hooks for something else, will secret-shield work with them?
 
-Yes! Secret-shield will automatically detect any local hooks that you have, e.g. husky, and run them instead. If you want to run secret-shield on that repository, you should add it to those local hooks. [Take a look here.](https://github.com/mapbox/secret-shield/blob/master/docs/enabledRepositories.md)
+Yes! Secret-shield will automatically detect any local hooks that you have, e.g. husky, and run them instead. If you want to run secret-shield on that repository, you should add it to those local hooks. [Take a look here.](https://github.com/mapbox/secret-shield/blob/main/docs/enabledRepositories.md)
 
 <a id="husky--lint-staged-integration"></a>
 ### Husky + lint-staged integration

--- a/checkInstalled.js
+++ b/checkInstalled.js
@@ -65,10 +65,10 @@ function checkInstalled(stopWorkingDate, path) {
     // There is no secret-shield
     if (new Date() > Date.parse(stopWorkingDate)) {
       // Grace period expired
-      console.error('ERROR! You must have secret-shield installed and configured globally to commit to this repository. To set up secret-shield, follow these instructions: https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md');
+      console.error('ERROR! You must have secret-shield installed and configured globally to commit to this repository. To set up secret-shield, follow these instructions: https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md');
       return 10;
     } else {
-      console.warn(`WARNING! You must have secret-shield installed and configured globally to commit to this repository. Committing will stop working on ${stopWorkingDate} if you don't globally install and configure secret-shield as detailed in the docs: https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md`);
+      console.warn(`WARNING! You must have secret-shield installed and configured globally to commit to this repository. Committing will stop working on ${stopWorkingDate} if you don't globally install and configure secret-shield as detailed in the docs: https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md`);
       return 255;
     }
   }
@@ -80,7 +80,7 @@ function checkInstalled(stopWorkingDate, path) {
       return 11;
     }
   } catch (e) {
-    console.error('ERROR! Secret-shield is installed but not working properly. Please run "npm install -g @mapbox/secret-shield@latest" to resolve this issue. If the issue persists, see https://github.com/mapbox/secret-shield/blob/master/docs/commonIssues.md');
+    console.error('ERROR! Secret-shield is installed but not working properly. Please run "npm install -g @mapbox/secret-shield@latest" to resolve this issue. If the issue persists, see https://github.com/mapbox/secret-shield/blob/main/docs/commonIssues.md');
     return 12;
   }
 
@@ -102,7 +102,7 @@ function checkVersionAndUpdate(path) {
       console.warn('WARNING! Could not update secret-shield to the latest version.');
       return -1;
     } else if (e.status === 112) {
-      console.error('ERROR! Could not point git hooks to new location. Run "secret-shield --add-hooks global", try again, and if you are still encountering issues, check out the documentation at https://github.com/mapbox/secret-shield/blob/master/docs/commonIssues.md for help.');
+      console.error('ERROR! Could not point git hooks to new location. Run "secret-shield --add-hooks global", try again, and if you are still encountering issues, check out the documentation at https://github.com/mapbox/secret-shield/blob/main/docs/commonIssues.md for help.');
       return 112;
     } else {
       console.warn('WARNING! Could not check secret-shield for updates due to an unknown error.');
@@ -138,7 +138,7 @@ function checkHooksGlobal(path) {
     try {
       fs.accessSync(hooksFile, (fs.constants || fs).X_OK);
     } catch (er) {
-      console.error(`ERROR! Your global pre-commit hooks located in ${hooksFile} are not executable. In order to commit to this repository, you must have global pre-commit hooks installed and configured to run secret-shield. To fix this issue, run chmod +x ${hooksFile} More info here: https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md`);
+      console.error(`ERROR! Your global pre-commit hooks located in ${hooksFile} are not executable. In order to commit to this repository, you must have global pre-commit hooks installed and configured to run secret-shield. To fix this issue, run chmod +x ${hooksFile} More info here: https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md`);
       return 21;
     }
   } else {
@@ -164,7 +164,7 @@ function checkHooksGlobal(path) {
   try {
     cp.execSync(`grep "secret-shield --pre-commit" ${hooksFile} >/dev/null 2>&1`);
   } catch (e) {
-    console.error(`ERROR! Your global pre-commit hooks located in ${hooksFile} are not configured to run secret-shield. In order to commit to this repository, your global pre-commit hooks must be configured to run secret-shield. More info here: https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md`);
+    console.error(`ERROR! Your global pre-commit hooks located in ${hooksFile} are not configured to run secret-shield. In order to commit to this repository, your global pre-commit hooks must be configured to run secret-shield. More info here: https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md`);
     return 24;
   }
   return 0;

--- a/docs/commonIssues.md
+++ b/docs/commonIssues.md
@@ -88,7 +88,7 @@ Follow these steps:
 This means that the `secret-shield` command is available in your terminal, but running it causes errors. Running `npm install -g @mapbox/secret-shield@latest` should resolve this issue. Make sure that your secret-shield installation is at `1.0.0-alpha.1` or above.
 
 If that didn't work, and when you installed secret-shield, you manually cloned the secret-shield github repository and ran `npm link`, try:
- * `git pull` in the directory (and `git checkout master` if you're not in the master branch)
+ * `git pull` in the directory (and `git checkout main` if you're not in the main branch)
  * `npm install`
  * `npm link`
 

--- a/docs/enabledBadge.md
+++ b/docs/enabledBadge.md
@@ -16,7 +16,7 @@ secret-shield --add-hooks global
 Follow these steps:
 1. Install secret-shield as described above, then try again.
 2. If that doesn't work, follow the errors that appear on-screen.
-3. If that doesn't work, [take a look here for common issues](https://github.com/mapbox/secret-shield/blob/master/docs/commonIssues.md).
+3. If that doesn't work, [take a look here for common issues](https://github.com/mapbox/secret-shield/blob/main/docs/commonIssues.md).
 4. If that doesn't work and you need to commit right now, run `git commit` with the `--no-verify` flag to skip all checks, including the check for secrets.
 5. If you need further help or want to report a bug, [open a ticket in secret-shield](https://github.com/mapbox/secret-shield/issues/new).
 6. If you need more immediate help, message us in the #secret-shield slack channel.

--- a/docs/enabledBadge.md
+++ b/docs/enabledBadge.md
@@ -1,6 +1,6 @@
-# I'm seeing [![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md) in some repos, what does it mean?
+# I'm seeing [![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md) in some repos, what does it mean?
 
-**Note:** [![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md) was previously called [![Secret-shield partner!](https://github.com/mapbox/secret-shield/blob/assets/partner-badge.svg)](https://github.com/mapbox/secret-shield/blob/master/docs/partnerBadge.md) prior to this repository's open-sourcing.
+**Note:** [![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md) was previously called [![Secret-shield partner!](https://github.com/mapbox/secret-shield/blob/assets/partner-badge.svg)](https://github.com/mapbox/secret-shield/blob/main/docs/partnerBadge.md) prior to this repository's open-sourcing.
 
 Some teams have decided to partner with secret-shield to help protect not only their repositories from accidentally committed secrets, but every other repository on the contributors' machines as well. You need to have secret-shield installed and configured globally if you want to commit to these partner repositories.
 

--- a/docs/enabledRepositories.md
+++ b/docs/enabledRepositories.md
@@ -1,4 +1,4 @@
-# Becoming a [![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md) repository
+# Becoming a [![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md) repository
 
 By simply adding one command to your repository's hooks manager as a pre-commit hook, secret-shield will automatically protect not only your repository, but every repository present in every computer that commits to your repository. This way, by partnering only with a few repositories, a team or organization can get secret-shield installed on most of their computers.
 
@@ -8,7 +8,7 @@ This is meant to be as a set-it-and-forget-it. You will not need to commit or ma
 
 1. Add secret-shield to your hooks manager (e.g. husky) alongside your other hooks: `secret-shield --check-and-run 2018-08-01 && myOtherHooks`, setting the date to your [desired grace period](#what-is-the-grace-period).
 4. Install secret-shield as an npm dependency in `package.json`. This is only needed for the command above and is not the actual secret-shield that will be run.
-5. Add the cool badge to your repository! Simply put `[![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/master/docs/enabledBadge.md)` at the top of your readme.
+5. Add the cool badge to your repository! Simply put `[![Secret-shield enabled](https://github.com/mapbox/secret-shield/blob/assets/secret-shield-enabled-badge.svg)](https://github.com/mapbox/secret-shield/blob/main/docs/enabledBadge.md)` at the top of your readme.
 
 ## FAQ
 


### PR DESCRIPTION
To support more inclusive terminology, this PR, in tandem with updating the repository's default branch to `main`, changes all references from master to main.