### PR TITLE
fix regex lib/analyzer.js:123,132,141

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -138,7 +138,7 @@ function analyzer(fileLocation, rules) {
       let ext = extractExtension(fileLocation);
 
       let templateFindings = [];
-      if (fileLocation.match('.template.js')) { // Dispatch to template searcher
+      if (fileLocation.endsWith('.template.js')) { // Dispatch to template searcher
         searchTemplate(fileLocation, rules).then((findings) => {
           templateFindings = findings;
         }, (failures) => {

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -120,7 +120,7 @@ function analyzer(fileLocation, rules) {
       const fileSizeLimit = (('special' in rules && 'FileSizeRestrictionInMB' in rules.special) ? rules.special.FileSizeRestrictionInMB : false);
       if (fileSizeLimit) {
         let fileSize = getFileSizeInMB(fileLocation);
-        if (!fileLocation.match('\\.min\\.js$') && !fileLocation.match('bundle\\.js$') && fileSize >= parseFloat(fileSizeLimit)) {
+        if (!fileLocation.endsWith('.min.js') && !fileLocation.endsWith('bundle.js') && fileSize >= parseFloat(fileSizeLimit)) {
           console.log(`Secret shield is not analyzing ${fileLocation} because the size of the file is ${fileSize} MB. Use a different rule if you want to analyze the file`);
           return resolve([]);
         }
@@ -129,7 +129,7 @@ function analyzer(fileLocation, rules) {
       const numberOfLinesLimit = (('special' in rules && 'NumberOfLinesRestriction' in rules.special) ? rules.special.NumberOfLinesRestriction : false);
       if (numberOfLinesLimit) {
         let noLines = numberOfLines(fileLocation);
-        if (!fileLocation.match('\\.min\\.js$') && !fileLocation.match('bundle\\.js$') && noLines >= parseFloat(numberOfLinesLimit)) {
+        if (!fileLocation.endsWith('.min.js') && !fileLocation.endsWith('bundle.js') && noLines >= parseFloat(numberOfLinesLimit)) {
           console.log(`Secret shield is not analyzing ${fileLocation} because it has ${noLines} lines. Use a different rule if you want to analyze the file`);
           return resolve([]);
         }
@@ -138,7 +138,7 @@ function analyzer(fileLocation, rules) {
       let ext = extractExtension(fileLocation);
 
       let templateFindings = [];
-      if (fileLocation.match('\\.template\\.js$')) { // Dispatch to template searcher
+      if (fileLocation.match('.template.js')) { // Dispatch to template searcher
         searchTemplate(fileLocation, rules).then((findings) => {
           templateFindings = findings;
         }, (failures) => {

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -120,7 +120,7 @@ function analyzer(fileLocation, rules) {
       const fileSizeLimit = (('special' in rules && 'FileSizeRestrictionInMB' in rules.special) ? rules.special.FileSizeRestrictionInMB : false);
       if (fileSizeLimit) {
         let fileSize = getFileSizeInMB(fileLocation);
-        if (!fileLocation.match('\.min\.js') && !fileLocation.match('bundle\.js') && fileSize >= parseFloat(fileSizeLimit)) {
+        if (!fileLocation.match('\\.min\\.js$') && !fileLocation.match('bundle\\.js$') && fileSize >= parseFloat(fileSizeLimit)) {
           console.log(`Secret shield is not analyzing ${fileLocation} because the size of the file is ${fileSize} MB. Use a different rule if you want to analyze the file`);
           return resolve([]);
         }
@@ -129,7 +129,7 @@ function analyzer(fileLocation, rules) {
       const numberOfLinesLimit = (('special' in rules && 'NumberOfLinesRestriction' in rules.special) ? rules.special.NumberOfLinesRestriction : false);
       if (numberOfLinesLimit) {
         let noLines = numberOfLines(fileLocation);
-        if (!fileLocation.match('\.min\.js') && !fileLocation.match('bundle\.js') && noLines >= parseFloat(numberOfLinesLimit)) {
+        if (!fileLocation.match('\\.min\\.js$') && !fileLocation.match('bundle\\.js$') && noLines >= parseFloat(numberOfLinesLimit)) {
           console.log(`Secret shield is not analyzing ${fileLocation} because it has ${noLines} lines. Use a different rule if you want to analyze the file`);
           return resolve([]);
         }
@@ -138,7 +138,7 @@ function analyzer(fileLocation, rules) {
       let ext = extractExtension(fileLocation);
 
       let templateFindings = [];
-      if (fileLocation.match('\.template\.js$')) { // Dispatch to template searcher
+      if (fileLocation.match('\\.template\\.js$')) { // Dispatch to template searcher
         searchTemplate(fileLocation, rules).then((findings) => {
           templateFindings = findings;
         }, (failures) => {


### PR DESCRIPTION
Fixes for issues #21 #22 #23 derived from CodeQL alerts 1 to 8

Fix provides a match to ONLY files ENDING with `.min.js`
