### PR TITLE
Fix Code Scanning Alert 9

### DIFF
--- a/utils/readfiles.js
+++ b/utils/readfiles.js
@@ -23,7 +23,7 @@ function buildFilter(filters) {
         return '[^\\/]*';
       })
       .replace(/\?/g, '[^\\/]?')
-      .replace(/\*\*/g, '\.*')
+      .replace(/\*\*/g, '.*')
       .replace(/([\-\+\|])/g, '\\$1')
     );
   }


### PR DESCRIPTION
Fixes unnecessary `\` character discussed in issue #20 about https://github.com/mapbox/secret-shield/security/code-scanning/9

See https://github.com/guatedude2/node-readfiles/pull/7 for discussion of this solution in the original forked library